### PR TITLE
Add JUCE C++ Amplitude Onset Detector module

### DIFF
--- a/juce_module/AmplitudeOnsetDetector.cpp
+++ b/juce_module/AmplitudeOnsetDetector.cpp
@@ -1,0 +1,316 @@
+#include "AmplitudeOnsetDetector.h"
+#include <cmath>
+
+namespace onset
+{
+
+EnvelopeFollower::EnvelopeFollower(int numChannels, float attack, float release, float floor)
+    : attackCoeff(1.0f / attack),
+      releaseCoeff(1.0f / release),
+      state(1, numChannels)
+{
+    for (int ch = 0; ch < numChannels; ++ch)
+        state.setSample(0, ch, floor);
+}
+
+void EnvelopeFollower::process(const juce::AudioBuffer<float>& in, juce::AudioBuffer<float>& out)
+{
+    auto numSamples = in.getNumSamples();
+    auto numChannels = in.getNumChannels();
+    out.setSize(numChannels, numSamples, false, false, true);
+
+    for (int ch = 0; ch < numChannels; ++ch)
+    {
+        float y = state.getSample(0, ch);
+        const float* x = in.getReadPointer(ch);
+        float* o = out.getWritePointer(ch);
+        for (int i = 0; i < numSamples; ++i)
+        {
+            float coeff = x[i] > y ? attackCoeff : releaseCoeff;
+            y += coeff * (x[i] - y);
+            o[i] = y;
+        }
+        state.setSample(0, ch, y);
+    }
+}
+
+MinMaxTracker::MinMaxTracker(int numChannels, float amin, float amax)
+    : alphaMin(amin), alphaMax(amax),
+      minVal(numChannels, 0.0f), maxVal(numChannels, 0.0f)
+{
+}
+
+void MinMaxTracker::process(const juce::AudioBuffer<float>& in)
+{
+    auto numSamples = in.getNumSamples();
+    auto numChannels = in.getNumChannels();
+    for (int ch = 0; ch < numChannels; ++ch)
+    {
+        auto* x = in.getReadPointer(ch);
+        float mn = minVal[ch];
+        float mx = maxVal[ch];
+        for (int i = 0; i < numSamples; ++i)
+        {
+            float v = x[i];
+            mn += alphaMin * (v - mn);
+            if (mn > v) mn = v;
+            mx += alphaMax * (v - mx);
+            if (mx < v) mx = v;
+        }
+        minVal[ch] = mn;
+        maxVal[ch] = mx;
+    }
+}
+
+AmplitudeOnsetDetector::AmplitudeOnsetDetector(int numChannels,
+                                               int blockSz,
+                                               float fl,
+                                               float hipassFreq,
+                                               std::pair<float, float> fastAR,
+                                               std::pair<float, float> slowAR,
+                                               float onThresh,
+                                               float offThresh,
+                                               int cool,
+                                               bool useBacktrack,
+                                               int backtrackBufferSize,
+                                               int backtrackSmoothSize,
+                                               float sr)
+    : nChannels(numChannels),
+      blockSize(blockSz),
+      floor(fl),
+      onThresholdValue(onThresh),
+      offThresholdValue(offThresh),
+      cooldown(cool),
+      manual(onThresh > 1.0f),
+      backtrack(useBacktrack),
+      sampleRate(sr),
+      fastSlide(numChannels, fastAR.first, fastAR.second, fl),
+      slowSlide(numChannels, slowAR.first, slowAR.second, fl),
+      minmax(numChannels, 1.0e-4f, 1.0e-5f),
+      state(numChannels, 0),
+      prevValues(numChannels, 0.0f),
+      debounce(numChannels, 0)
+{
+    if (hipassFreq > 0.0f)
+    {
+        hipass = std::make_unique<juce::dsp::ProcessorDuplicator<
+            juce::dsp::IIR::Filter<float>,
+            juce::dsp::IIR::Coefficients<float>>>();
+        auto coeff = juce::dsp::IIR::Coefficients<float>::makeHighPass(sr, hipassFreq);
+        hipass->state = *coeff;
+    }
+
+    if (backtrack)
+    {
+        backtrackBuffer.setSize(numChannels, backtrackBufferSize);
+        backtrackBuffer.clear();
+        bAlpha = 2.0f / (backtrackSmoothSize + 1.0f);
+        bTol = std::pow(1.0f - bAlpha, (float)backtrackBufferSize);
+    }
+}
+
+void AmplitudeOnsetDetector::processBlock(const juce::AudioBuffer<float>& input,
+                                          std::vector<int>& channels,
+                                          std::vector<int>& deltas,
+                                          juce::AudioBuffer<float>* relativeEnvelope)
+{
+    jassert(input.getNumSamples() == blockSize);
+    juce::AudioBuffer<float> x(input);
+    if (hipass)
+    {
+        juce::dsp::AudioBlock<float> block(x);
+        juce::dsp::ProcessContextReplacing<float> ctx(block);
+        hipass->process(ctx);
+    }
+
+    // Convert to dB and clip
+    for (int ch = 0; ch < nChannels; ++ch)
+    {
+        float* data = x.getWritePointer(ch);
+        for (int i = 0; i < blockSize; ++i)
+        {
+            float v = std::abs(data[i]) + 1.0e-10f;
+            v = 20.0f * std::log10(v);
+            if (v < floor)
+                v = floor;
+            data[i] = v;
+        }
+    }
+
+    juce::AudioBuffer<float> fast(blockSize, nChannels);
+    juce::AudioBuffer<float> slow(blockSize, nChannels);
+    fastSlide.process(x, fast);
+    slowSlide.process(x, slow);
+
+    juce::AudioBuffer<float> rel(blockSize, nChannels);
+    for (int ch = 0; ch < nChannels; ++ch)
+    {
+        const float* f = fast.getReadPointer(ch);
+        const float* s = slow.getReadPointer(ch);
+        float* r = rel.getWritePointer(ch);
+        for (int i = 0; i < blockSize; ++i)
+        {
+            float diff = f[i] - s[i];
+            float amp = std::pow(10.0f, diff / 20.0f) - 1.0e-10f;
+            if (amp < 0.0f) amp = 0.0f;
+            if (amp > -floor) amp = -floor;
+            r[i] = amp;
+        }
+    }
+
+    if (backtrack)
+    {
+        for (int ch = 0; ch < nChannels; ++ch)
+        {
+            const float* r = rel.getReadPointer(ch);
+            for (int i = 0; i < blockSize; ++i)
+                backtrackBuffer.setSample(ch, (backtrackIndex + i) % backtrackBuffer.getNumSamples(), r[i]);
+        }
+        backtrackIndex = (backtrackIndex + blockSize) % backtrackBuffer.getNumSamples();
+    }
+
+    std::vector<float> onThresh(nChannels), offThresh(nChannels);
+    if (manual)
+    {
+        std::fill(onThresh.begin(), onThresh.end(), onThresholdValue);
+        std::fill(offThresh.begin(), offThresh.end(), offThresholdValue);
+    }
+    else
+    {
+        minmax.process(rel);
+        const auto& mi = minmax.getMin();
+        const auto& ma = minmax.getMax();
+        for (int ch = 0; ch < nChannels; ++ch)
+        {
+            onThresh[ch] = ma[ch] * onThresholdValue + mi[ch];
+            offThresh[ch] = ma[ch] * offThresholdValue + mi[ch];
+        }
+    }
+
+    std::vector<int> onIndex(nChannels, 0);
+    std::vector<char> on(nChannels, 0);
+
+    for (int ch = 0; ch < nChannels; ++ch)
+    {
+        const float* r = rel.getReadPointer(ch);
+        if (debounce[ch] > 0)
+            debounce[ch] -= blockSize;
+        for (int i = 0; i < blockSize; ++i)
+        {
+            if (!state[ch] && debounce[ch] < 1 && r[i] > onThresh[ch] &&
+                ((i == 0 ? prevValues[ch] : r[i - 1]) <= onThresh[ch]))
+            {
+                on[ch] = 1;
+                onIndex[ch] = i;
+                state[ch] = 1;
+                debounce[ch] = cooldown;
+                break;
+            }
+        }
+        // turn off after off threshold
+        if (state[ch])
+        {
+            for (int i = onIndex[ch]; i < blockSize; ++i)
+            {
+                if (r[i] < offThresh[ch])
+                {
+                    state[ch] = 0;
+                    break;
+                }
+            }
+        }
+        prevValues[ch] = r[blockSize - 1];
+    }
+
+    for (int ch = 0; ch < nChannels; ++ch)
+    {
+        if (on[ch])
+        {
+            channels.push_back(ch);
+            deltas.push_back(onIndex[ch]);
+        }
+    }
+
+    if (backtrack && !channels.empty())
+        backtrackOnsets(channels, deltas);
+
+    if (relativeEnvelope)
+        *relativeEnvelope = rel;
+}
+
+void AmplitudeOnsetDetector::backtrackOnsets(std::vector<int>& channels, std::vector<int>& deltas)
+{
+    int N = backtrackBuffer.getNumSamples();
+    for (size_t j = 0; j < channels.size(); ++j)
+    {
+        int ch = channels[j];
+        int delta = deltas[j];
+        int i = blockSize - delta;
+        auto readSample = [this, N, ch](int idx)
+        {
+            int pos = (backtrackIndex - idx + N) % N;
+            return backtrackBuffer.getSample(ch, pos);
+        };
+        float currentSmoothed = readSample(i);
+        i++;
+        float prev = readSample(i);
+        float prevSmoothed = bAlpha * prev + (1.0f - bAlpha) * currentSmoothed;
+        while (currentSmoothed > prevSmoothed && std::abs(prevSmoothed - prev) > bTol && (i + 1 < N))
+        {
+            deltas[j] -= 1;
+            i++;
+            currentSmoothed = prevSmoothed;
+            prev = readSample(i);
+            prevSmoothed = bAlpha * prev + (1.0f - bAlpha) * currentSmoothed;
+        }
+    }
+}
+
+void AmplitudeOnsetDetector::initMinMaxTracker(const juce::AudioBuffer<float>& buffer)
+{
+    // Similar to processBlock but only updates the min/max tracker.
+    juce::AudioBuffer<float> x(buffer);
+    if (hipass)
+    {
+        juce::dsp::AudioBlock<float> block(x);
+        juce::dsp::ProcessContextReplacing<float> ctx(block);
+        hipass->process(ctx);
+    }
+
+    for (int ch = 0; ch < nChannels; ++ch)
+    {
+        float* data = x.getWritePointer(ch);
+        for (int i = 0; i < x.getNumSamples(); ++i)
+        {
+            float v = std::abs(data[i]) + 1.0e-10f;
+            v = 20.0f * std::log10(v);
+            if (v < floor) v = floor;
+            data[i] = v;
+        }
+    }
+
+    juce::AudioBuffer<float> fastBuf(x.getNumChannels(), x.getNumSamples());
+    juce::AudioBuffer<float> slowBuf(x.getNumChannels(), x.getNumSamples());
+    fastSlide.process(x, fastBuf);
+    slowSlide.process(x, slowBuf);
+
+    juce::AudioBuffer<float> rel(x.getNumChannels(), x.getNumSamples());
+    for (int ch = 0; ch < nChannels; ++ch)
+    {
+        const float* f = fastBuf.getReadPointer(ch);
+        const float* s = slowBuf.getReadPointer(ch);
+        float* r = rel.getWritePointer(ch);
+        for (int i = 0; i < x.getNumSamples(); ++i)
+        {
+            float diff = f[i] - s[i];
+            float amp = std::pow(10.0f, diff / 20.0f) - 1.0e-10f;
+            if (amp < 0.0f) amp = 0.0f;
+            if (amp > -floor) amp = -floor;
+            r[i] = amp;
+        }
+    }
+    minmax.process(rel);
+}
+
+} // namespace onset
+

--- a/juce_module/AmplitudeOnsetDetector.h
+++ b/juce_module/AmplitudeOnsetDetector.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_dsp/juce_dsp.h>
+#include <vector>
+#include <memory>
+
+namespace onset
+{
+
+/** Simple attack / release envelope follower for multi-channel audio. */
+class EnvelopeFollower
+{
+public:
+    EnvelopeFollower(int numChannels, float attack, float release, float floor);
+
+    /** Processes a block of samples and writes the envelope to \p out. */
+    void process(const juce::AudioBuffer<float>& in, juce::AudioBuffer<float>& out);
+
+private:
+    float attackCoeff;
+    float releaseCoeff;
+    juce::AudioBuffer<float> state; // one sample per channel
+};
+
+/** Exponential moving min / max tracker for onset thresholds. */
+class MinMaxTracker
+{
+public:
+    MinMaxTracker(int numChannels, float alphaMin, float alphaMax);
+    void process(const juce::AudioBuffer<float>& in);
+    const std::vector<float>& getMin() const { return minVal; }
+    const std::vector<float>& getMax() const { return maxVal; }
+
+private:
+    float alphaMin, alphaMax;
+    std::vector<float> minVal, maxVal;
+};
+
+/**
+    Port of the Python AmplitudeOnsetDetector to a JUCE friendly C++ class.
+
+    The detector compares fast and slow envelope followers and flags an onset
+    whenever their relative difference crosses a threshold.
+*/
+class AmplitudeOnsetDetector
+{
+public:
+    AmplitudeOnsetDetector(int numChannels,
+                           int blockSize,
+                           float floor = -70.0f,
+                           float hipassFreq = 2000.0f,
+                           std::pair<float, float> fastAR = {3.0f, 383.0f},
+                           std::pair<float, float> slowAR = {2205.0f, 2205.0f},
+                           float onThreshold = 0.5f,
+                           float offThreshold = 0.1f,
+                           int cooldown = 1323,
+                           bool backtrack = false,
+                           int backtrackBufferSize = 80,
+                           int backtrackSmoothSize = 5,
+                           float sampleRate = 44100.0f);
+
+    /**
+        Process one block of audio.  The input buffer must contain
+        `blockSize` samples.
+
+        Detected channel indices and sample offsets are returned in \p channels
+        and \p deltas respectively.
+    */
+    void processBlock(const juce::AudioBuffer<float>& input,
+                      std::vector<int>& channels,
+                      std::vector<int>& deltas,
+                      juce::AudioBuffer<float>* relativeEnvelope = nullptr);
+
+    /** Initialise the min/max tracker with an existing buffer that contains
+        a representative slice of the incoming audio. */
+    void initMinMaxTracker(const juce::AudioBuffer<float>& buffer);
+
+private:
+    int nChannels;
+    int blockSize;
+    float floor;
+    float onThresholdValue;
+    float offThresholdValue;
+    int cooldown;
+    bool manual;
+    bool backtrack;
+    float sampleRate;
+
+    std::unique_ptr<juce::dsp::ProcessorDuplicator<
+        juce::dsp::IIR::Filter<float>,
+        juce::dsp::IIR::Coefficients<float>>> hipass;
+
+    EnvelopeFollower fastSlide;
+    EnvelopeFollower slowSlide;
+    MinMaxTracker minmax;
+
+    std::vector<char> state;
+    std::vector<float> prevValues;
+    std::vector<int> debounce;
+
+    juce::AudioBuffer<float> backtrackBuffer;
+    int backtrackIndex = 0;
+    float bAlpha = 0.0f;
+    float bTol = 0.0f;
+
+    void backtrackOnsets(std::vector<int>& channels, std::vector<int>& deltas);
+};
+
+} // namespace onset
+

--- a/juce_module/README.md
+++ b/juce_module/README.md
@@ -1,0 +1,88 @@
+# JUCE Amplitude Onset Detector
+
+This folder contains a C++ port of the Python
+`AmplitudeOnsetDetector` class found in `onset_fingerprinting/detection.py`.
+The class is implemented as a JUCE-friendly module so it can be used directly
+inside audio plug-ins or applications.
+
+## Structure
+
+- `AmplitudeOnsetDetector.h` – public API and helper classes.
+- `AmplitudeOnsetDetector.cpp` – implementation of the onset detector.
+
+## Using the module
+
+Add the two source files to your JUCE project and include the header:
+
+```cpp
+#include "AmplitudeOnsetDetector.h"
+
+onset::AmplitudeOnsetDetector detector (numChannels, blockSize);
+```
+
+The `processBlock` function expects a `juce::AudioBuffer<float>` containing
+`blockSize` samples.  Detected channel indices and sample offsets are returned
+in the supplied `channels` and `deltas` vectors.
+
+## Porting notes
+
+The original implementation makes heavy use of NumPy arrays and Python's
+flexible typing.  Converting it to C++ required the following changes:
+
+### Arrays and memory
+
+* **Python**: `numpy.ndarray` objects store multi-channel audio and support
+  vectorised operations.
+* **C++**: JUCE's `AudioBuffer<float>` is used to hold sample blocks.  All
+  operations are expressed as explicit loops over channels and samples.
+
+### Envelope followers
+
+* The Python version calls a compiled C extension for fast attack–release
+  envelope following.
+* In C++ the `EnvelopeFollower` class implements the same exponential
+  smoothing in pure C++.  Each call processes one block and updates the per
+  channel state.
+
+### Min/Max tracking
+
+* Python relies on a C library (`EMA_MinMaxTracker.so`) to maintain the recent
+  range of the relative envelope.
+* `MinMaxTracker` replicates this behaviour with simple exponential moving
+  averages for the minimum and maximum values.
+
+### High-pass filtering
+
+* The Python detector designs a Butterworth filter using SciPy and stores the
+  filter state between calls.
+* JUCE's `dsp::IIR::Filter` and `dsp::ProcessorDuplicator` are used to create a
+  high-pass filter that is applied in-place to each block.
+
+### Control flow and state
+
+* Python makes heavy use of boolean masking and broadcasting to find threshold
+  crossings.  In C++ these checks are implemented explicitly with loops and
+  per-channel state vectors (`state`, `prevValues`, `debounce`).
+* Optional backtracking is implemented with a circular buffer and mirrors the
+  logic from the Python version.
+
+### Boilerplate
+
+* C++ requires forward declarations, header guards (`#pragma once`) and
+  explicit namespaces.  Constructors initialise members using an initialiser
+  list and `std::vector` replaces Python lists.
+* The JUCE module is self-contained and does not depend on any other files in
+  the repository.
+
+## Initialisation
+
+Call `initMinMaxTracker` with a buffer containing representative audio before
+processing real-time data.  This pre-fills the min/max tracker similarly to the
+Python class' `init_minmax_tracker` method.
+
+## Notes
+
+This module focuses on clarity rather than maximal optimisation.  Further
+performance improvements are possible by using SIMD operations or custom DSP
+code where appropriate.
+


### PR DESCRIPTION
## Summary
- Port AmplitudeOnsetDetector from Python to JUCE-friendly C++ module
- Document differences between Python and C++ implementations and usage instructions

## Testing
- `python -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68af1bbba754832b802e416cc8c7d412